### PR TITLE
Binary Fixes

### DIFF
--- a/__tests__/errorHandling.unit.js
+++ b/__tests__/errorHandling.unit.js
@@ -19,9 +19,6 @@ const api8 = require('../index')({ version: 'v1.0', logger: { access: 'never', e
 const api9 = require('../index')({
   version: 'v1.0',
   isBase64: true,
-  headers: {
-   // 'content-encoding': ['gzip']
-  },
   serializer: {
     delegate: (body, acceptableMedia) => {
       const json = JSON.stringify(Object.assign(body, { _custom: true, _base64: true }))

--- a/__tests__/errorHandling.unit.js
+++ b/__tests__/errorHandling.unit.js
@@ -20,11 +20,17 @@ const api9 = require('../index')({
   version: 'v1.0',
   isBase64: true,
   headers: {
-    'content-encoding': ['gzip']
+   // 'content-encoding': ['gzip']
   },
-  serializer: body => {
-    const json = JSON.stringify(Object.assign(body,{ _custom: true, _base64: true }))
-    return gzipSync(json).toString('base64')
+  serializer: {
+    delegate: (body, acceptableMedia) => {
+      const json = JSON.stringify(Object.assign(body, { _custom: true, _base64: true }))
+      return {
+        value: gzipSync(json),
+        contentType: 'application/json',
+        contentEncoding: 'gzip'
+      }
+    }
   }
 })
 
@@ -271,31 +277,31 @@ describe('Error Handling Tests:', function() {
     it('RouteError', async function() {
       let _event = Object.assign({},event,{ path: '/testx'})
       let result = await new Promise(r => api_errors.run(_event,{},(e,res) => { r(res) }))
-      expect(result).toEqual({ multiValueHeaders: { }, statusCode: 404, body: '{"errorType":"RouteError"}', isBase64Encoded: false })
+      expect(result).toEqual({ multiValueHeaders: { 'content-type': ['application/json'] }, statusCode: 404, body: '{"errorType":"RouteError"}', isBase64Encoded: false })
     }) // end it
 
     it('MethodError', async function() {
       let _event = Object.assign({},event,{ path: '/fileError', httpMethod: 'put' })
       let result = await new Promise(r => api_errors.run(_event,{},(e,res) => { r(res) }))
-      expect(result).toEqual({ multiValueHeaders: { }, statusCode: 405, body: '{"errorType":"MethodError"}', isBase64Encoded: false })
+      expect(result).toEqual({ multiValueHeaders: { 'content-type': ['application/json'] }, statusCode: 405, body: '{"errorType":"MethodError"}', isBase64Encoded: false })
     }) // end it
 
     it('FileError (s3)', async function() {
       let _event = Object.assign({},event,{ path: '/fileError' })
       let result = await new Promise(r => api_errors.run(_event,{},(e,res) => { r(res) }))
-      expect(result).toEqual({ multiValueHeaders: { }, statusCode: 500, body: '{"errorType":"FileError"}', isBase64Encoded: false })
+      expect(result).toEqual({ multiValueHeaders: { 'content-type': ['application/json'] }, statusCode: 500, body: '{"errorType":"FileError"}', isBase64Encoded: false })
     }) // end it
 
     it('FileError (local)', async function() {
       let _event = Object.assign({},event,{ path: '/fileErrorLocal' })
       let result = await new Promise(r => api_errors.run(_event,{},(e,res) => { r(res) }))
-      expect(result).toEqual({ multiValueHeaders: { }, statusCode: 500, body: '{"errorType":"FileError"}', isBase64Encoded: false })
+      expect(result).toEqual({ multiValueHeaders: { 'content-type': ['application/json'] }, statusCode: 500, body: '{"errorType":"FileError"}', isBase64Encoded: false })
     }) // end it
 
     it('ResponseError', async function() {
       let _event = Object.assign({},event,{ path: '/responseError' })
       let result = await new Promise(r => api_errors.run(_event,{},(e,res) => { r(res) }))
-      expect(result).toEqual({ multiValueHeaders: { }, statusCode: 500, body: '{"errorType":"ResponseError"}', isBase64Encoded: false })
+      expect(result).toEqual({ multiValueHeaders: { 'content-type': ['application/json'] }, statusCode: 500, body: '{"errorType":"ResponseError"}', isBase64Encoded: false })
     }) // end it
   })
 

--- a/__tests__/parsing.unit.js
+++ b/__tests__/parsing.unit.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const { parseAccept } = require("../lib/parsing");
+
+describe("Parsing Test:", function () {
+    describe("parseAccept:", function () {
+        it("Sorting", function () {
+            const acceptableMedia = parseAccept({
+                "accept":
+                    "text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8",
+            }, ["application/xml"]);
+            expect(acceptableMedia[0]).toBe("application/xml");
+        });
+        it("Group Alphabetically", function () {
+            const acceptableMedia = parseAccept({
+                "accept": "application/json, application/bebop, text/html",
+            }, []);
+            expect(acceptableMedia).toEqual([
+                "application/bebop",
+                "application/json",
+                "text/html",
+            ]);
+        });
+        it("No Explicit Weights", function () {
+            const acceptableMedia = parseAccept({
+                "accept":
+                    "application/vnd.wap.wmlscriptc, text/vnd.wap.wml, application/vnd.wap.xhtml+xml, application/xhtml+xml, text/html, multipart/mixed, */*",
+            }, []);
+            expect(acceptableMedia).toEqual([
+                "application/vnd.wap.wmlscriptc",
+                "application/vnd.wap.xhtml+xml",
+                "application/xhtml+xml",
+                "multipart/mixed",
+                "text/html",
+                "text/vnd.wap.wml",
+                "*/*",
+            ]);
+        });
+        it("Partial Types", function () {
+            const acceptableMedia = parseAccept({
+                "accept": "text/*, image/*",
+            }, []);
+            expect(acceptableMedia).toEqual(["image/*", "text/*"]);
+        });
+
+        it("Empty Accept", function () {
+            const acceptableMedia = parseAccept({
+                "accept": "",
+            }, []);
+            expect(acceptableMedia).toEqual(["*/*"]);
+        });
+        it("Null Accept", function () {
+            const acceptableMedia = parseAccept({
+                "accept": "null",
+            }, []);
+            expect(acceptableMedia).toEqual([]);
+        });
+        it("Invalid Preference", function () {
+
+            expect(() => {
+                parseAccept({
+                    "accept": "application/json, application/bebop, text/html",
+                }, ["*/json"]);
+            }).toThrow();
+
+        });
+    });
+});

--- a/__tests__/routes.unit.js
+++ b/__tests__/routes.unit.js
@@ -1182,6 +1182,9 @@ describe("Route Tests:", function () {
         httpMethod: "post",
         body: "VGVzdCBmaWxlIGZvciBzZW5kRmlsZQo=",
         isBase64Encoded: true,
+        multiValueHeaders: {
+          "content-type": ["text/plain"],
+        },
       });
       let result = await new Promise((r) =>
         api.run(_event, {}, (e, res) => {

--- a/__tests__/utils.unit.js
+++ b/__tests__/utils.unit.js
@@ -43,19 +43,19 @@ describe("Utility Function Tests:", function () {
 
   describe("encodeBody:", function () {
     it("String", function () {
-      expect(utils.encodeBody("test string")).toBe("test string");
+      expect(utils.encodeBody("test string").value).toBe("test string");
     }); // end it
 
     it("Number", function () {
-      expect(utils.encodeBody(123)).toBe("123");
+      expect(utils.encodeBody(123).value).toBe("123");
     }); // end it
 
     it("Array", function () {
-      expect(utils.encodeBody([1, 2, 3])).toBe("[1,2,3]");
+      expect(utils.encodeBody([1, 2, 3]).value).toBe("[1,2,3]");
     }); // end it
 
     it("Object", function () {
-      expect(utils.encodeBody({ foo: "bar" })).toBe('{"foo":"bar"}');
+      expect(utils.encodeBody({ foo: "bar" }).value).toBe('{"foo":"bar"}');
     }); // end it
   }); // end encodeBody tests
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,7 +62,8 @@ export declare type HandlerFunction = (
 export declare type LoggerFunction = (message: string) => void;
 export declare type NextFunction = () => void;
 export declare type TimestampFunction = () => string;
-export declare type SerializerFunction = (body: object) => string;
+export declare type DeserializerFunction = (body: Buffer | string | object, contentType: string) => object | string;
+export declare type SerializerFunction = (body: object, acceptableMedia: string[]) => SerializerResult;
 export declare type FinallyFunction = (req: Request, res: Response) => void;
 export declare type METHODS =
   | 'GET'
@@ -106,6 +107,22 @@ export declare interface LoggerOptions {
   stack?: boolean;
 }
 
+export declare interface DeserializerOptions {
+  delegate?: DeserializerFunction;
+}
+
+export declare interface SerializerOptions {
+  delegate?: SerializerFunction;
+  preferences?: string[];
+}
+
+export declare interface SerializerResult {
+  value?: Buffer | string,
+  contentType?: string,
+  isBase64Encoded?: boolean,
+  contentEncoding?: 'gzip' | 'compress' | 'deflate' | 'br'
+} 
+
 export declare interface Options {
   base?: string;
   callbackName?: string;
@@ -113,7 +130,8 @@ export declare interface Options {
   mimeTypes?: {
     [key: string]: string;
   };
-  serializer?: SerializerFunction;
+  deserializer?: DeserializerFunction;
+  serializer?: SerializerOptions;
   version?: string;
   errorHeaderWhitelist?: string[];
   isBase64?: boolean;
@@ -142,8 +160,8 @@ export declare class Request {
   rawHeaders?: {
     [key: string]: string | undefined;
   };
-  body: any;
-  rawBody: string;
+  body: Buffer | string | object | undefined;
+  rawBody: string | undefined;
   route: '';
   requestContext: APIGatewayEventRequestContext;
   isBase64Encoded: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -306,14 +306,14 @@ export declare class ResponseError extends Error {
 }
 
 export declare class FileError extends Error {
-  constructor(message: string, err: object);
+  constructor(message: string, err?: object);
 }
 
 export declare class DeserializationError extends Error {
-  constructor(message: string, contentType: string, err: object);
+  constructor(message: string, contentType: string, err?: object);
 }
 export declare class SerializationError extends Error {
-  constructor(message: string, contentType: string, err: object);
+  constructor(message: string, contentType: string, err?: object);
 }
 
 export declare class RequestError extends Error {

--- a/index.d.ts
+++ b/index.d.ts
@@ -130,7 +130,7 @@ export declare interface Options {
   mimeTypes?: {
     [key: string]: string;
   };
-  deserializer?: DeserializerFunction;
+  deserializer?: DeserializerOptions;
   serializer?: SerializerOptions;
   version?: string;
   errorHeaderWhitelist?: string[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -160,8 +160,8 @@ export declare class Request {
   rawHeaders?: {
     [key: string]: string | undefined;
   };
-  body: any | undefined;
-  rawBody: string | undefined;
+  body?: any;
+  rawBody?: string;
   route: '';
   requestContext: APIGatewayEventRequestContext;
   isBase64Encoded: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,11 +108,11 @@ export declare interface LoggerOptions {
 }
 
 export declare interface DeserializerOptions {
-  delegate?: DeserializerFunction;
+  callback?: DeserializerFunction;
 }
 
 export declare interface SerializerOptions {
-  delegate?: SerializerFunction;
+  callback?: SerializerFunction;
   preferences?: string[];
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -303,6 +303,17 @@ export declare class FileError extends Error {
   constructor(message: string, err: object);
 }
 
+export declare class DeserializationError extends Error {
+  constructor(message: string, contentType: string, err: object);
+}
+export declare class SerializationError extends Error {
+  constructor(message: string, contentType: string, err: object);
+}
+
+export declare class RequestError extends Error {
+  constructor(message: string, code: number);
+}
+
 declare function createAPI(options?: Options): API;
 
 export default createAPI;

--- a/index.d.ts
+++ b/index.d.ts
@@ -160,7 +160,7 @@ export declare class Request {
   rawHeaders?: {
     [key: string]: string | undefined;
   };
-  body: Buffer | string | object | undefined;
+  body: any | undefined;
   rawBody: string | undefined;
   route: '';
   requestContext: APIGatewayEventRequestContext;

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,8 +62,14 @@ export declare type HandlerFunction = (
 export declare type LoggerFunction = (message: string) => void;
 export declare type NextFunction = () => void;
 export declare type TimestampFunction = () => string;
-export declare type DeserializerFunction = (body: Buffer | string | object, contentType: string) => object | string;
-export declare type SerializerFunction = (body: object, acceptableMedia: string[]) => SerializerResult;
+export declare type DeserializerFunction = (
+  body: Buffer | string | object,
+  contentType: string
+) => object | string;
+export declare type SerializerFunction = (
+  body: object,
+  acceptableMedia: string[]
+) => SerializerResult;
 export declare type FinallyFunction = (req: Request, res: Response) => void;
 export declare type METHODS =
   | 'GET'
@@ -117,11 +123,11 @@ export declare interface SerializerOptions {
 }
 
 export declare interface SerializerResult {
-  value?: Buffer | string,
-  contentType?: string,
-  isBase64Encoded?: boolean,
-  contentEncoding?: 'gzip' | 'compress' | 'deflate' | 'br'
-} 
+  value?: Buffer | string;
+  contentType?: string;
+  isBase64Encoded?: boolean;
+  contentEncoding?: 'gzip' | 'compress' | 'deflate' | 'br';
+}
 
 export declare interface Options {
   base?: string;

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const RESPONSE = require('./lib/response'); // Response object
 const UTILS = require('./lib/utils'); // Require utils library
 const LOGGER = require('./lib/logger'); // Require logger library
 const prettyPrint = require('./lib/prettyPrint'); // Pretty print for debugging
-const { ConfigurationError } = require('./lib/errors'); // Require custom errors
+const ERRORS = require('./lib/errors'); // Require custom errors
 
 // Create the API class
 class API {
@@ -152,13 +152,13 @@ class API {
         (fn.length === 3 || i === args.length - 1)
       )
         return fn;
-      throw new ConfigurationError(
+      throw new ERRORS.ConfigurationError(
         'Route-based middleware must have 3 parameters'
       );
     });
 
     if (stack.length === 0)
-      throw new ConfigurationError(
+      throw new ERRORS.ConfigurationError(
         `No handler or middleware specified for ${method} method on ${path} route.`
       );
 
@@ -303,7 +303,7 @@ class API {
 
             // If there's a wild card that's not at the end
           } else if (route[i] === '*') {
-            throw new ConfigurationError(
+            throw new ERRORS.ConfigurationError(
               'Wildcards can only be at the end of a route definition'
             );
           } // end if end of path
@@ -495,7 +495,7 @@ class API {
         } else if (args[arg].length === 4) {
           this._errors.push(args[arg]);
         } else {
-          throw new ConfigurationError(
+          throw new ERRORS.ConfigurationError(
             'Middleware must have 3 or 4 parameters'
           );
         }
@@ -584,5 +584,11 @@ class API {
 
 // Export the API class as a new instance
 module.exports = (opts) => new API(opts);
+
+// export all the error types too
+for (const key in ERRORS) {
+  module.exports[key] = ERRORS[key];
+}
+
 // Add createAPI as default export (to match index.d.ts)
 module.exports.default = module.exports;

--- a/index.js
+++ b/index.js
@@ -30,10 +30,25 @@ class API {
       props && props.mimeTypes && typeof props.mimeTypes === 'object'
         ? props.mimeTypes
         : {};
-    this._serializer =
-      props && props.serializer && typeof props.serializer === 'function'
-        ? props.serializer
-        : JSON.stringify;
+
+    this._deserializer = undefined;
+    if (props && props.deserializer && typeof props.deserializer === 'object') {
+      if (props.deserializer.delegate && typeof props.deserializer.delegate === 'function') {
+        this._deserializer = props.deserializer.delegate;
+      }
+    }
+
+    this._serializer = UTILS.stringifyBody;
+    this._serializerPreferences = []
+    if (props && props.serializer && typeof props.serializer === 'object') {
+      if (props.serializer.delegate && typeof props.serializer.delegate === 'function') {
+        this._serializer = props.serializer.delegate;
+      }
+      if (Array.isArray(props.serializer.preferences)) {
+        this._serializerPreferences = props.serializer.preferences;
+      }
+    }
+    
     this._errorHeaderWhitelist =
       props && Array.isArray(props.errorHeaderWhitelist)
         ? props.errorHeaderWhitelist.map((header) => header.toLowerCase())
@@ -50,6 +65,13 @@ class API {
         Array.isArray(props.compression))
         ? props.compression
         : false;
+
+    this._compression =
+        props &&
+        (typeof props.compression === 'boolean' ||
+          Array.isArray(props.compression))
+          ? props.compression
+          : false;
 
     // Set sampling info
     this._sampleCounts = {};

--- a/index.js
+++ b/index.js
@@ -33,16 +33,16 @@ class API {
 
     this._deserializer = undefined;
     if (props && props.deserializer && typeof props.deserializer === 'object') {
-      if (props.deserializer.delegate && typeof props.deserializer.delegate === 'function') {
-        this._deserializer = props.deserializer.delegate;
+      if (props.deserializer.callback && typeof props.deserializer.callback === 'function') {
+        this._deserializer = props.deserializer.callback;
       }
     }
 
     this._serializer = UTILS.stringifyBody;
     this._serializerPreferences = []
     if (props && props.serializer && typeof props.serializer === 'object') {
-      if (props.serializer.delegate && typeof props.serializer.delegate === 'function') {
-        this._serializer = props.serializer.delegate;
+      if (props.serializer.callback && typeof props.serializer.callback === 'function') {
+        this._serializer = props.serializer.callback;
       }
       if (Array.isArray(props.serializer.preferences)) {
         this._serializerPreferences = props.serializer.preferences;

--- a/index.js
+++ b/index.js
@@ -33,22 +33,28 @@ class API {
 
     this._deserializer = undefined;
     if (props && props.deserializer && typeof props.deserializer === 'object') {
-      if (props.deserializer.callback && typeof props.deserializer.callback === 'function') {
+      if (
+        props.deserializer.callback &&
+        typeof props.deserializer.callback === 'function'
+      ) {
         this._deserializer = props.deserializer.callback;
       }
     }
 
     this._serializer = UTILS.stringifyBody;
-    this._serializerPreferences = []
+    this._serializerPreferences = [];
     if (props && props.serializer && typeof props.serializer === 'object') {
-      if (props.serializer.callback && typeof props.serializer.callback === 'function') {
+      if (
+        props.serializer.callback &&
+        typeof props.serializer.callback === 'function'
+      ) {
         this._serializer = props.serializer.callback;
       }
       if (Array.isArray(props.serializer.preferences)) {
         this._serializerPreferences = props.serializer.preferences;
       }
     }
-    
+
     this._errorHeaderWhitelist =
       props && Array.isArray(props.errorHeaderWhitelist)
         ? props.errorHeaderWhitelist.map((header) => header.toLowerCase())
@@ -67,11 +73,11 @@ class API {
         : false;
 
     this._compression =
-        props &&
-        (typeof props.compression === 'boolean' ||
-          Array.isArray(props.compression))
-          ? props.compression
-          : false;
+      props &&
+      (typeof props.compression === 'boolean' ||
+        Array.isArray(props.compression))
+        ? props.compression
+        : false;
 
     // Set sampling info
     this._sampleCounts = {};

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -44,7 +44,7 @@ class FileError extends Error {
   constructor(message, err) {
     super(message);
     this.name = this.constructor.name;
-    for (let e in err) this[e] = err[e];
+    if (err) for (let e in err) this[e] = err[e];
   }
 }
 
@@ -53,7 +53,7 @@ class DeserializationError extends Error {
     super(message);
     this.contentType = contentType;
     this.name = this.constructor.name;
-    for (let e in err) this[e] = err[e];
+    if (err) for (let e in err) this[e] = err[e];
   }
 }
 
@@ -62,7 +62,7 @@ class SerializationError extends Error {
     super(message);
     this.contentType = contentType;
     this.name = this.constructor.name;
-    for (let e in err) this[e] = err[e];
+    if (err) for (let e in err) this[e] = err[e];
   }
 }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -83,5 +83,5 @@ module.exports = {
   FileError,
   SerializationError,
   RequestError,
-  DeserializationError
+  DeserializationError,
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -48,6 +48,32 @@ class FileError extends Error {
   }
 }
 
+class DeserializationError extends Error {
+  constructor(message, contentType, err) {
+    super(message);
+    this.contentType = contentType;
+    this.name = this.constructor.name;
+    for (let e in err) this[e] = err[e];
+  }
+}
+
+class SerializationError extends Error {
+  constructor(message, contentType, err) {
+    super(message);
+    this.contentType = contentType;
+    this.name = this.constructor.name;
+    for (let e in err) this[e] = err[e];
+  }
+}
+
+class RequestError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.name = this.constructor.name;
+    this.code = code;
+  }
+}
+
 // Export the response object
 module.exports = {
   RouteError,
@@ -55,4 +81,7 @@ module.exports = {
   ConfigurationError,
   ResponseError,
   FileError,
+  SerializationError,
+  RequestError,
+  DeserializationError
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -53,7 +53,7 @@ class DeserializationError extends Error {
     super(message);
     this.contentType = contentType;
     this.name = this.constructor.name;
-    if (err) for (let e in err) this[e] = err[e];
+    if (err) this.innerError = err;
   }
 }
 
@@ -62,7 +62,7 @@ class SerializationError extends Error {
     super(message);
     this.contentType = contentType;
     this.name = this.constructor.name;
-    if (err) for (let e in err) this[e] = err[e];
+    if (err) this.innerError = err;
   }
 }
 

--- a/lib/parsing.js
+++ b/lib/parsing.js
@@ -1,0 +1,235 @@
+"use strict";
+
+const { RequestError, ConfigurationError } = require("./errors");
+
+/**
+ * A parser for the Accept header
+ * @param {Object.<string, string|undefined>} requestHeaders
+ * @param {string[]} preferences
+ */
+exports.parseAccept = (requestHeaders, preferences) => {
+    //                         */*        type/*                              type/subtype
+    const validMediaRx = /^(?:\*\/\*)|(?:[\w\!#\$%&'\*\+\-\.\^`\|~]+\/\*)|(?:[\w\!#\$%&'\*\+\-\.\^`\|~]+\/[\w\!#\$%&'\*\+\-\.\^`\|~]+)$/;
+    const normalize = (raw) => {
+        raw = raw || "*/*";
+        const normalized = {
+            header: raw,
+            quoted: {},
+        };
+        if (raw.includes('"')) {
+            let i = 0;
+            normalized.header = raw.replace(/="([^"]*)"/g, ($0, $1) => {
+                const key = '"' + ++i;
+                normalized.quoted[key] = $1;
+                return "=" + key;
+            });
+        }
+        normalized.header = normalized.header.replace(/[ \t]/g, "");
+        return normalized;
+    };
+    const { header, quoted } = normalize(requestHeaders["accept"] ?? "");
+    const parts = header.split(',');
+    const selections = [];
+    const map = {};
+    for (let i = 0; i < parts.length; ++i) {
+        const part = parts[i];
+        // Ignore empty parts or leading commas
+        if (!part) {
+            continue;
+        }
+
+        // Parse parameters
+        const pairs = part.split(';');
+        const token = pairs.shift().toLowerCase();
+        // Ignore invalid types
+        if (!validMediaRx.test(token)) {
+            continue;
+        }
+
+        const selection = {
+            token,
+            params: {},
+            exts: {},
+            pos: i
+        };
+
+        // Parse key=value
+
+        let target = 'params';
+        for (const pair of pairs) {
+            const kv = pair.split('=');
+            if (kv.length !== 2 ||
+                !kv[1]) {
+
+                throw new RequestError(`Invalid accept header`, 400);
+            }
+
+            const key = kv[0];
+            let value = kv[1];
+
+            if (key === 'q' ||
+                key === 'Q') {
+
+                target = 'exts';
+
+                value = parseFloat(value);
+                if (!Number.isFinite(value) ||
+                    value > 1 ||
+                    (value < 0.001 && value !== 0)) {
+
+                    value = 1;
+                }
+
+                selection.q = value;
+            }
+            else {
+                if (value[0] === '"') {
+                    value = `"${quoted[value]}"`;
+                }
+
+                selection[target][kv[0]] = value;
+            }
+        }
+
+        const params = Object.keys(selection.params);
+        selection.original = [''].concat(params.map((key) => `${key}=${selection.params[key]}`)).join(';');
+        selection.specificity = params.length;
+        // Default no preference to q=1 (top preference)
+        if (selection.q === undefined) {
+            selection.q = 1;
+        }
+
+        const tparts = selection.token.split('/');
+        selection.type = tparts[0];
+        selection.subtype = tparts[1];
+
+        map[selection.token] = selection;
+        // Skip denied selections (q=0)
+        if (selection.q) {
+            selections.push(selection);
+        }
+    }
+
+    // Sort selection based on q and then position in header
+
+    selections.sort((a, b) => {
+        const innerSort = (key) => {
+            const aFirst = -1;
+            const bFirst = 1;
+            if (a[key] === '*') {
+                return bFirst;
+            }
+            if (b[key] === '*') {
+                return aFirst;
+            }
+            // Group alphabetically
+            return a[key] < b[key] ? aFirst : bFirst;
+        }
+        // Sort by quality score
+        if (b.q !== a.q) {
+            return b.q - a.q;
+        }
+        // Sort by type
+        if (a.type !== b.type) {
+            return innerSort('type');
+        }
+        // Sort by subtype
+        if (a.subtype !== b.subtype) {
+            return innerSort('subtype');
+        }
+        // Sort by specificity
+        if (a.specificity !== b.specificity) {
+            return b.specificity - a.specificity;
+        }
+        return a.pos - b.pos;
+    });
+
+    // Return selections if no preferences
+    if (!preferences ||
+        !preferences.length) {
+
+        return selections.map((selection) => selection.token + selection.original);
+    }
+
+    // Map wildcards and filter selections to preferences
+
+    const lowers = Object.create(null);
+    const flat = Object.create(null);
+    let any = false;
+
+    for (const preference of preferences) {
+        const lower = preference.toLowerCase();
+        flat[lower] = preference;
+        const parts = lower.split('/');
+        const type = parts[0];
+        const subtype = parts[1];
+  
+
+        if (type === '*') {
+            if (subtype !== '*') {
+                throw new ConfigurationError('Invalid media type preference contains wildcard type with a subtype')
+            }
+            any = true;
+            continue;
+        }
+
+        lowers[type] = lowers[type] || Object.create(null);
+        lowers[type][subtype] = preference;
+    }
+
+    const preferred = [];
+    for (const selection of selections) {
+        const token = selection.token;
+        const { type, subtype } = map[token];
+        const subtypes = lowers[type];
+
+        // */*
+
+        if (type === '*') {
+            for (const preference of Object.keys(flat)) {
+                if (!map[preference]) {
+                    preferred.push(flat[preference]);
+                }
+            }
+
+            if (any) {
+                preferred.push('*/*');
+            }
+
+            continue;
+        }
+
+        // any
+
+        if (any) {
+            preferred.push((flat[token] || token) + selection.original);
+            continue;
+        }
+
+        // type/subtype
+
+        if (subtype !== '*') {
+            const pref = flat[token];
+            if (pref ||
+                (subtypes && subtypes['*'])) {
+
+                preferred.push((pref || token) + selection.original);
+            }
+
+            continue;
+        }
+
+        // type/*
+
+        if (subtypes) {
+            for (const psub of Object.keys(subtypes)) {
+                if (!map[`${type}/${psub}`]) {
+                    preferred.push(subtypes[psub]);
+                }
+            }
+        }
+    }
+
+    return preferred;
+
+};

--- a/lib/parsing.js
+++ b/lib/parsing.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-const { RequestError, ConfigurationError } = require("./errors");
+const { RequestError, ConfigurationError } = require('./errors');
 
 /**
  * A parser for the Accept header
@@ -8,228 +8,223 @@ const { RequestError, ConfigurationError } = require("./errors");
  * @param {string[]} preferences
  */
 exports.parseAccept = (requestHeaders, preferences) => {
-    //                         */*        type/*                              type/subtype
-    const validMediaRx = /^(?:\*\/\*)|(?:[\w\!#\$%&'\*\+\-\.\^`\|~]+\/\*)|(?:[\w\!#\$%&'\*\+\-\.\^`\|~]+\/[\w\!#\$%&'\*\+\-\.\^`\|~]+)$/;
-    const normalize = (raw) => {
-        raw = raw || "*/*";
-        const normalized = {
-            header: raw,
-            quoted: {},
-        };
-        if (raw.includes('"')) {
-            let i = 0;
-            normalized.header = raw.replace(/="([^"]*)"/g, ($0, $1) => {
-                const key = '"' + ++i;
-                normalized.quoted[key] = $1;
-                return "=" + key;
-            });
-        }
-        normalized.header = normalized.header.replace(/[ \t]/g, "");
-        return normalized;
+  //                         */*        type/*                              type/subtype
+  const validMediaRx =
+    /^(?:\*\/\*)|(?:[\w\!#\$%&'\*\+\-\.\^`\|~]+\/\*)|(?:[\w\!#\$%&'\*\+\-\.\^`\|~]+\/[\w\!#\$%&'\*\+\-\.\^`\|~]+)$/;
+  const normalize = (raw) => {
+    raw = raw || '*/*';
+    const normalized = {
+      header: raw,
+      quoted: {},
     };
-    const { header, quoted } = normalize(requestHeaders["accept"] ?? "");
-    const parts = header.split(',');
-    const selections = [];
-    const map = {};
-    for (let i = 0; i < parts.length; ++i) {
-        const part = parts[i];
-        // Ignore empty parts or leading commas
-        if (!part) {
-            continue;
-        }
-
-        // Parse parameters
-        const pairs = part.split(';');
-        const token = pairs.shift().toLowerCase();
-        // Ignore invalid types
-        if (!validMediaRx.test(token)) {
-            continue;
-        }
-
-        const selection = {
-            token,
-            params: {},
-            exts: {},
-            pos: i
-        };
-
-        // Parse key=value
-
-        let target = 'params';
-        for (const pair of pairs) {
-            const kv = pair.split('=');
-            if (kv.length !== 2 ||
-                !kv[1]) {
-
-                throw new RequestError(`Invalid accept header`, 400);
-            }
-
-            const key = kv[0];
-            let value = kv[1];
-
-            if (key === 'q' ||
-                key === 'Q') {
-
-                target = 'exts';
-
-                value = parseFloat(value);
-                if (!Number.isFinite(value) ||
-                    value > 1 ||
-                    (value < 0.001 && value !== 0)) {
-
-                    value = 1;
-                }
-
-                selection.q = value;
-            }
-            else {
-                if (value[0] === '"') {
-                    value = `"${quoted[value]}"`;
-                }
-
-                selection[target][kv[0]] = value;
-            }
-        }
-
-        const params = Object.keys(selection.params);
-        selection.original = [''].concat(params.map((key) => `${key}=${selection.params[key]}`)).join(';');
-        selection.specificity = params.length;
-        // Default no preference to q=1 (top preference)
-        if (selection.q === undefined) {
-            selection.q = 1;
-        }
-
-        const tparts = selection.token.split('/');
-        selection.type = tparts[0];
-        selection.subtype = tparts[1];
-
-        map[selection.token] = selection;
-        // Skip denied selections (q=0)
-        if (selection.q) {
-            selections.push(selection);
-        }
+    if (raw.includes('"')) {
+      let i = 0;
+      normalized.header = raw.replace(/="([^"]*)"/g, ($0, $1) => {
+        const key = '"' + ++i;
+        normalized.quoted[key] = $1;
+        return '=' + key;
+      });
+    }
+    normalized.header = normalized.header.replace(/[ \t]/g, '');
+    return normalized;
+  };
+  const { header, quoted } = normalize(requestHeaders['accept'] ?? '');
+  const parts = header.split(',');
+  const selections = [];
+  const map = {};
+  for (let i = 0; i < parts.length; ++i) {
+    const part = parts[i];
+    // Ignore empty parts or leading commas
+    if (!part) {
+      continue;
     }
 
-    // Sort selection based on q and then position in header
-
-    selections.sort((a, b) => {
-        const innerSort = (key) => {
-            const aFirst = -1;
-            const bFirst = 1;
-            if (a[key] === '*') {
-                return bFirst;
-            }
-            if (b[key] === '*') {
-                return aFirst;
-            }
-            // Group alphabetically
-            return a[key] < b[key] ? aFirst : bFirst;
-        }
-        // Sort by quality score
-        if (b.q !== a.q) {
-            return b.q - a.q;
-        }
-        // Sort by type
-        if (a.type !== b.type) {
-            return innerSort('type');
-        }
-        // Sort by subtype
-        if (a.subtype !== b.subtype) {
-            return innerSort('subtype');
-        }
-        // Sort by specificity
-        if (a.specificity !== b.specificity) {
-            return b.specificity - a.specificity;
-        }
-        return a.pos - b.pos;
-    });
-
-    // Return selections if no preferences
-    if (!preferences ||
-        !preferences.length) {
-
-        return selections.map((selection) => selection.token + selection.original);
+    // Parse parameters
+    const pairs = part.split(';');
+    const token = pairs.shift().toLowerCase();
+    // Ignore invalid types
+    if (!validMediaRx.test(token)) {
+      continue;
     }
 
-    // Map wildcards and filter selections to preferences
+    const selection = {
+      token,
+      params: {},
+      exts: {},
+      pos: i,
+    };
 
-    const lowers = Object.create(null);
-    const flat = Object.create(null);
-    let any = false;
+    // Parse key=value
 
-    for (const preference of preferences) {
-        const lower = preference.toLowerCase();
-        flat[lower] = preference;
-        const parts = lower.split('/');
-        const type = parts[0];
-        const subtype = parts[1];
-  
+    let target = 'params';
+    for (const pair of pairs) {
+      const kv = pair.split('=');
+      if (kv.length !== 2 || !kv[1]) {
+        throw new RequestError(`Invalid accept header`, 400);
+      }
 
-        if (type === '*') {
-            if (subtype !== '*') {
-                throw new ConfigurationError('Invalid media type preference contains wildcard type with a subtype')
-            }
-            any = true;
-            continue;
+      const key = kv[0];
+      let value = kv[1];
+
+      if (key === 'q' || key === 'Q') {
+        target = 'exts';
+
+        value = parseFloat(value);
+        if (
+          !Number.isFinite(value) ||
+          value > 1 ||
+          (value < 0.001 && value !== 0)
+        ) {
+          value = 1;
         }
 
-        lowers[type] = lowers[type] || Object.create(null);
-        lowers[type][subtype] = preference;
+        selection.q = value;
+      } else {
+        if (value[0] === '"') {
+          value = `"${quoted[value]}"`;
+        }
+
+        selection[target][kv[0]] = value;
+      }
     }
 
-    const preferred = [];
-    for (const selection of selections) {
-        const token = selection.token;
-        const { type, subtype } = map[token];
-        const subtypes = lowers[type];
-
-        // */*
-
-        if (type === '*') {
-            for (const preference of Object.keys(flat)) {
-                if (!map[preference]) {
-                    preferred.push(flat[preference]);
-                }
-            }
-
-            if (any) {
-                preferred.push('*/*');
-            }
-
-            continue;
-        }
-
-        // any
-
-        if (any) {
-            preferred.push((flat[token] || token) + selection.original);
-            continue;
-        }
-
-        // type/subtype
-
-        if (subtype !== '*') {
-            const pref = flat[token];
-            if (pref ||
-                (subtypes && subtypes['*'])) {
-
-                preferred.push((pref || token) + selection.original);
-            }
-
-            continue;
-        }
-
-        // type/*
-
-        if (subtypes) {
-            for (const psub of Object.keys(subtypes)) {
-                if (!map[`${type}/${psub}`]) {
-                    preferred.push(subtypes[psub]);
-                }
-            }
-        }
+    const params = Object.keys(selection.params);
+    selection.original = ['']
+      .concat(params.map((key) => `${key}=${selection.params[key]}`))
+      .join(';');
+    selection.specificity = params.length;
+    // Default no preference to q=1 (top preference)
+    if (selection.q === undefined) {
+      selection.q = 1;
     }
 
-    return preferred;
+    const tparts = selection.token.split('/');
+    selection.type = tparts[0];
+    selection.subtype = tparts[1];
 
+    map[selection.token] = selection;
+    // Skip denied selections (q=0)
+    if (selection.q) {
+      selections.push(selection);
+    }
+  }
+
+  // Sort selection based on q and then position in header
+
+  selections.sort((a, b) => {
+    const innerSort = (key) => {
+      const aFirst = -1;
+      const bFirst = 1;
+      if (a[key] === '*') {
+        return bFirst;
+      }
+      if (b[key] === '*') {
+        return aFirst;
+      }
+      // Group alphabetically
+      return a[key] < b[key] ? aFirst : bFirst;
+    };
+    // Sort by quality score
+    if (b.q !== a.q) {
+      return b.q - a.q;
+    }
+    // Sort by type
+    if (a.type !== b.type) {
+      return innerSort('type');
+    }
+    // Sort by subtype
+    if (a.subtype !== b.subtype) {
+      return innerSort('subtype');
+    }
+    // Sort by specificity
+    if (a.specificity !== b.specificity) {
+      return b.specificity - a.specificity;
+    }
+    return a.pos - b.pos;
+  });
+
+  // Return selections if no preferences
+  if (!preferences || !preferences.length) {
+    return selections.map((selection) => selection.token + selection.original);
+  }
+
+  // Map wildcards and filter selections to preferences
+
+  const lowers = Object.create(null);
+  const flat = Object.create(null);
+  let any = false;
+
+  for (const preference of preferences) {
+    const lower = preference.toLowerCase();
+    flat[lower] = preference;
+    const parts = lower.split('/');
+    const type = parts[0];
+    const subtype = parts[1];
+
+    if (type === '*') {
+      if (subtype !== '*') {
+        throw new ConfigurationError(
+          'Invalid media type preference contains wildcard type with a subtype'
+        );
+      }
+      any = true;
+      continue;
+    }
+
+    lowers[type] = lowers[type] || Object.create(null);
+    lowers[type][subtype] = preference;
+  }
+
+  const preferred = [];
+  for (const selection of selections) {
+    const token = selection.token;
+    const { type, subtype } = map[token];
+    const subtypes = lowers[type];
+
+    // */*
+
+    if (type === '*') {
+      for (const preference of Object.keys(flat)) {
+        if (!map[preference]) {
+          preferred.push(flat[preference]);
+        }
+      }
+
+      if (any) {
+        preferred.push('*/*');
+      }
+
+      continue;
+    }
+
+    // any
+
+    if (any) {
+      preferred.push((flat[token] || token) + selection.original);
+      continue;
+    }
+
+    // type/subtype
+
+    if (subtype !== '*') {
+      const pref = flat[token];
+      if (pref || (subtypes && subtypes['*'])) {
+        preferred.push((pref || token) + selection.original);
+      }
+
+      continue;
+    }
+
+    // type/*
+
+    if (subtypes) {
+      for (const psub of Object.keys(subtypes)) {
+        if (!map[`${type}/${psub}`]) {
+          preferred.push(subtypes[psub]);
+        }
+      }
+    }
+  }
+
+  return preferred;
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -74,8 +74,8 @@ class REQUEST {
     this.method = this.app._event.httpMethod
       ? this.app._event.httpMethod.toUpperCase()
       : this.app._event.requestContext && this.app._event.requestContext.http
-        ? this.app._event.requestContext.http.method.toUpperCase()
-        : 'GET';
+      ? this.app._event.requestContext.http.method.toUpperCase()
+      : 'GET';
 
     // Set the path
     this.path =
@@ -90,21 +90,21 @@ class REQUEST {
       'queryStringParameters' in this.app._event
         ? {} // do nothing
         : Object.keys(
-          Object.assign({}, this.app._event.multiValueQueryStringParameters)
-        ).reduce(
-          (qs, key) =>
-            Object.assign(
-              qs, // get the last value of the array
-              {
-                [key]: decodeURIComponent(
-                  this.app._event.multiValueQueryStringParameters[key].slice(
-                    -1
-                  )[0]
-                ),
-              }
-            ),
-          {}
-        )
+            Object.assign({}, this.app._event.multiValueQueryStringParameters)
+          ).reduce(
+            (qs, key) =>
+              Object.assign(
+                qs, // get the last value of the array
+                {
+                  [key]: decodeURIComponent(
+                    this.app._event.multiValueQueryStringParameters[key].slice(
+                      -1
+                    )[0]
+                  ),
+                }
+              ),
+            {}
+          )
     );
 
     // Set the multi-value query parameters (simulate if no multi-value support)
@@ -113,10 +113,10 @@ class REQUEST {
       this._multiValueSupport
         ? {}
         : Object.keys(this.query).reduce(
-          (qs, key) =>
-            Object.assign(qs, { [key]: this.query[key].split(',') }),
-          {}
-        ),
+            (qs, key) =>
+              Object.assign(qs, { [key]: this.query[key].split(',') }),
+            {}
+          ),
       this.app._event.multiValueQueryStringParameters
     );
 
@@ -125,12 +125,12 @@ class REQUEST {
     this.rawHeaders =
       this._multiValueSupport && this.app._event.multiValueHeaders !== null
         ? Object.keys(this.app._event.multiValueHeaders).reduce(
-          (headers, key) =>
-            Object.assign(headers, {
-              [key]: UTILS.fromArray(this.app._event.multiValueHeaders[key]),
-            }),
-          {}
-        )
+            (headers, key) =>
+              Object.assign(headers, {
+                [key]: UTILS.fromArray(this.app._event.multiValueHeaders[key]),
+              }),
+            {}
+          )
         : this.app._event.headers || {};
 
     // Set the headers to lowercase
@@ -143,12 +143,12 @@ class REQUEST {
     this.multiValueHeaders = this._multiValueSupport
       ? this.app._event.multiValueHeaders
       : Object.keys(this.headers).reduce(
-        (headers, key) =>
-          Object.assign(headers, {
-            [key.toLowerCase()]: this.headers[key].split(','),
-          }),
-        {}
-      );
+          (headers, key) =>
+            Object.assign(headers, {
+              [key.toLowerCase()]: this.headers[key].split(','),
+            }),
+          {}
+        );
 
     // Extract user agent
     this.userAgent = this.headers['user-agent'];
@@ -157,8 +157,8 @@ class REQUEST {
     let cookies = this.app._event.cookies
       ? this.app._event.cookies
       : this.headers.cookie
-        ? this.headers.cookie.split(';')
-        : [];
+      ? this.headers.cookie.split(';')
+      : [];
 
     // Set and parse cookies
     this.cookies = cookies.reduce((acc, cookie) => {
@@ -208,12 +208,12 @@ class REQUEST {
       this.headers['cloudfront-is-desktop-viewer'] === 'true'
         ? 'desktop'
         : this.headers['cloudfront-is-mobile-viewer'] === 'true'
-          ? 'mobile'
-          : this.headers['cloudfront-is-smarttv-viewer'] === 'true'
-            ? 'tv'
-            : this.headers['cloudfront-is-tablet-viewer'] === 'true'
-              ? 'tablet'
-              : 'unknown';
+        ? 'mobile'
+        : this.headers['cloudfront-is-smarttv-viewer'] === 'true'
+        ? 'tv'
+        : this.headers['cloudfront-is-tablet-viewer'] === 'true'
+        ? 'tablet'
+        : 'unknown';
 
     // Parse country
     this.clientCountry = this.headers['cloudfront-viewer-country']
@@ -228,32 +228,45 @@ class REQUEST {
       ? Buffer.from(this.app._event.body || '', 'base64')
       : this.app._event.body;
 
-
     // At this point 'this.body' is either a Buffer or a string
     // While the 'content-type' header is not required by HTTP body parsing only happens if one is present.
     if (this.headers['content-type']) {
-      const contentType = this.headers['content-type'].split(';')[0].toLowerCase().trim();
+      const contentType = this.headers['content-type']
+        .split(';')[0]
+        .toLowerCase()
+        .trim();
       if (contentType) {
         // if a deserializer is defined, use that.
         if (this.app._deserializer) {
-          this.body = this.app._deserializer(this.body, contentType)
+          this.body = this.app._deserializer(this.body, contentType);
         } else {
           // when a buffer is encountered with a known text content type it is turned into a string.
-          if (Buffer.isBuffer(this.body) && (contentType === 'application/json' || contentType === 'application/x-www-form-urlencoded' || contentType.startsWith('text/'))) {
-            this.body = this.body.toString("utf8");
+          if (
+            Buffer.isBuffer(this.body) &&
+            (contentType === 'application/json' ||
+              contentType === 'application/x-www-form-urlencoded' ||
+              contentType.startsWith('text/'))
+          ) {
+            this.body = this.body.toString('utf8');
           }
-          // any body that is not handled below is passed through either as a buffer or a string. 
+          // any body that is not handled below is passed through either as a buffer or a string.
           if (this.body) {
             // if a deserializer is defined, use that.
             if (contentType === 'application/x-www-form-urlencoded') {
               this.body = QS.parse(this.body);
-            } else if (contentType === 'application/json' && typeof this.body !== "object") {
+            } else if (
+              contentType === 'application/json' &&
+              typeof this.body !== 'object'
+            ) {
               try {
                 this.body = JSON.parse(this.body);
               } catch (e) {
                 // if the content type of a request is 'application/json' but it cannot be parsed
                 // that indicates a bad request and an exception is raised.
-                throw new DeserializationError(`Unable to parse body as JSON: ${e.message}`, e)
+                throw new DeserializationError(
+                  `Unable to parse body as JSON: ${e.message}`,
+                  e
+                );
               }
             }
           }
@@ -311,16 +324,16 @@ class REQUEST {
       routes['METHODS'] && routes['METHODS'][this.method]
         ? routes['METHODS'][this.method]
         : routes['METHODS'] && routes['METHODS']['ANY']
-          ? routes['METHODS']['ANY']
-          : wildcard && wildcard['METHODS'] && wildcard['METHODS'][this.method]
-            ? wildcard['METHODS'][this.method]
-            : wildcard && wildcard['METHODS'] && wildcard['METHODS']['ANY']
-              ? wildcard['METHODS']['ANY']
-              : this.method === 'HEAD' &&
-                routes['METHODS'] &&
-                routes['METHODS']['GET']
-                ? routes['METHODS']['GET']
-                : undefined;
+        ? routes['METHODS']['ANY']
+        : wildcard && wildcard['METHODS'] && wildcard['METHODS'][this.method]
+        ? wildcard['METHODS'][this.method]
+        : wildcard && wildcard['METHODS'] && wildcard['METHODS']['ANY']
+        ? wildcard['METHODS']['ANY']
+        : this.method === 'HEAD' &&
+          routes['METHODS'] &&
+          routes['METHODS']['GET']
+        ? routes['METHODS']['GET']
+        : undefined;
 
     // Check for the requested method
     if (route) {
@@ -360,9 +373,9 @@ class REQUEST {
   logger(...args) {
     this.app._logger.level !== 'none' &&
       this.app._logLevels[args[0]] >=
-      this.app._logLevels[
-      this._sample ? this._sample : this.app._logger.level
-      ] &&
+        this.app._logLevels[
+          this._sample ? this._sample : this.app._logger.level
+        ] &&
       this._logs.push(this.app._logger.log(...args));
   }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -9,7 +9,7 @@
 const QS = require('querystring'); // Require the querystring library
 const UTILS = require('./utils'); // Require utils library
 const LOGGER = require('./logger'); // Require logger library
-const { RouteError, MethodError } = require('./errors'); // Require custom errors
+const { RouteError, MethodError, DeserializationError } = require('./errors'); // Require custom errors
 
 class REQUEST {
   // Create the constructor function.
@@ -74,8 +74,8 @@ class REQUEST {
     this.method = this.app._event.httpMethod
       ? this.app._event.httpMethod.toUpperCase()
       : this.app._event.requestContext && this.app._event.requestContext.http
-      ? this.app._event.requestContext.http.method.toUpperCase()
-      : 'GET';
+        ? this.app._event.requestContext.http.method.toUpperCase()
+        : 'GET';
 
     // Set the path
     this.path =
@@ -90,21 +90,21 @@ class REQUEST {
       'queryStringParameters' in this.app._event
         ? {} // do nothing
         : Object.keys(
-            Object.assign({}, this.app._event.multiValueQueryStringParameters)
-          ).reduce(
-            (qs, key) =>
-              Object.assign(
-                qs, // get the last value of the array
-                {
-                  [key]: decodeURIComponent(
-                    this.app._event.multiValueQueryStringParameters[key].slice(
-                      -1
-                    )[0]
-                  ),
-                }
-              ),
-            {}
-          )
+          Object.assign({}, this.app._event.multiValueQueryStringParameters)
+        ).reduce(
+          (qs, key) =>
+            Object.assign(
+              qs, // get the last value of the array
+              {
+                [key]: decodeURIComponent(
+                  this.app._event.multiValueQueryStringParameters[key].slice(
+                    -1
+                  )[0]
+                ),
+              }
+            ),
+          {}
+        )
     );
 
     // Set the multi-value query parameters (simulate if no multi-value support)
@@ -113,10 +113,10 @@ class REQUEST {
       this._multiValueSupport
         ? {}
         : Object.keys(this.query).reduce(
-            (qs, key) =>
-              Object.assign(qs, { [key]: this.query[key].split(',') }),
-            {}
-          ),
+          (qs, key) =>
+            Object.assign(qs, { [key]: this.query[key].split(',') }),
+          {}
+        ),
       this.app._event.multiValueQueryStringParameters
     );
 
@@ -125,12 +125,12 @@ class REQUEST {
     this.rawHeaders =
       this._multiValueSupport && this.app._event.multiValueHeaders !== null
         ? Object.keys(this.app._event.multiValueHeaders).reduce(
-            (headers, key) =>
-              Object.assign(headers, {
-                [key]: UTILS.fromArray(this.app._event.multiValueHeaders[key]),
-              }),
-            {}
-          )
+          (headers, key) =>
+            Object.assign(headers, {
+              [key]: UTILS.fromArray(this.app._event.multiValueHeaders[key]),
+            }),
+          {}
+        )
         : this.app._event.headers || {};
 
     // Set the headers to lowercase
@@ -143,12 +143,12 @@ class REQUEST {
     this.multiValueHeaders = this._multiValueSupport
       ? this.app._event.multiValueHeaders
       : Object.keys(this.headers).reduce(
-          (headers, key) =>
-            Object.assign(headers, {
-              [key.toLowerCase()]: this.headers[key].split(','),
-            }),
-          {}
-        );
+        (headers, key) =>
+          Object.assign(headers, {
+            [key.toLowerCase()]: this.headers[key].split(','),
+          }),
+        {}
+      );
 
     // Extract user agent
     this.userAgent = this.headers['user-agent'];
@@ -157,8 +157,8 @@ class REQUEST {
     let cookies = this.app._event.cookies
       ? this.app._event.cookies
       : this.headers.cookie
-      ? this.headers.cookie.split(';')
-      : [];
+        ? this.headers.cookie.split(';')
+        : [];
 
     // Set and parse cookies
     this.cookies = cookies.reduce((acc, cookie) => {
@@ -208,36 +208,57 @@ class REQUEST {
       this.headers['cloudfront-is-desktop-viewer'] === 'true'
         ? 'desktop'
         : this.headers['cloudfront-is-mobile-viewer'] === 'true'
-        ? 'mobile'
-        : this.headers['cloudfront-is-smarttv-viewer'] === 'true'
-        ? 'tv'
-        : this.headers['cloudfront-is-tablet-viewer'] === 'true'
-        ? 'tablet'
-        : 'unknown';
+          ? 'mobile'
+          : this.headers['cloudfront-is-smarttv-viewer'] === 'true'
+            ? 'tv'
+            : this.headers['cloudfront-is-tablet-viewer'] === 'true'
+              ? 'tablet'
+              : 'unknown';
 
     // Parse country
     this.clientCountry = this.headers['cloudfront-viewer-country']
       ? this.headers['cloudfront-viewer-country'].toUpperCase()
       : 'unknown';
 
-    // Capture the raw body
-    this.rawBody = this.app._event.body;
+    // Capture the body
 
+    this.rawBody = this.app._event.body;
     // Set the body (decode it if base64 encoded)
     this.body = this.app._event.isBase64Encoded
-      ? Buffer.from(this.app._event.body || '', 'base64').toString()
+      ? Buffer.from(this.app._event.body || '', 'base64')
       : this.app._event.body;
 
-    // Set the body
-    if (
-      this.headers['content-type'] &&
-      this.headers['content-type'].includes('application/x-www-form-urlencoded')
-    ) {
-      this.body = QS.parse(this.body);
-    } else if (typeof this.body === 'object') {
-      // Do nothing
-    } else {
-      this.body = UTILS.parseBody(this.body);
+
+    // At this point 'this.body' is either a Buffer or a string
+    // While the 'content-type' header is not required by HTTP body parsing only happens if one is present.
+    if (this.headers['content-type']) {
+      const contentType = this.headers['content-type'].split(';')[0].toLowerCase().trim();
+      if (contentType) {
+        // if a deserializer is defined, use that.
+        if (this.app._deserializer) {
+          this.body = this.app._deserializer(this.body, contentType)
+        } else {
+          // when a buffer is encountered with a known text content type it is turned into a string.
+          if (Buffer.isBuffer(this.body) && (contentType === 'application/json' || contentType === 'application/x-www-form-urlencoded' || contentType.startsWith('text/'))) {
+            this.body = this.body.toString("utf8");
+          }
+          // any body that is not handled below is passed through either as a buffer or a string. 
+          if (this.body) {
+            // if a deserializer is defined, use that.
+            if (contentType === 'application/x-www-form-urlencoded') {
+              this.body = QS.parse(this.body);
+            } else if (contentType === 'application/json' && typeof this.body !== "object") {
+              try {
+                this.body = JSON.parse(this.body);
+              } catch (e) {
+                // if the content type of a request is 'application/json' but it cannot be parsed
+                // that indicates a bad request and an exception is raised.
+                throw new DeserializationError(`Unable to parse body as JSON: ${e.message}`, e)
+              }
+            }
+          }
+        }
+      }
     }
 
     // Init the stack reporter
@@ -290,16 +311,16 @@ class REQUEST {
       routes['METHODS'] && routes['METHODS'][this.method]
         ? routes['METHODS'][this.method]
         : routes['METHODS'] && routes['METHODS']['ANY']
-        ? routes['METHODS']['ANY']
-        : wildcard && wildcard['METHODS'] && wildcard['METHODS'][this.method]
-        ? wildcard['METHODS'][this.method]
-        : wildcard && wildcard['METHODS'] && wildcard['METHODS']['ANY']
-        ? wildcard['METHODS']['ANY']
-        : this.method === 'HEAD' &&
-          routes['METHODS'] &&
-          routes['METHODS']['GET']
-        ? routes['METHODS']['GET']
-        : undefined;
+          ? routes['METHODS']['ANY']
+          : wildcard && wildcard['METHODS'] && wildcard['METHODS'][this.method]
+            ? wildcard['METHODS'][this.method]
+            : wildcard && wildcard['METHODS'] && wildcard['METHODS']['ANY']
+              ? wildcard['METHODS']['ANY']
+              : this.method === 'HEAD' &&
+                routes['METHODS'] &&
+                routes['METHODS']['GET']
+                ? routes['METHODS']['GET']
+                : undefined;
 
     // Check for the requested method
     if (route) {
@@ -339,9 +360,9 @@ class REQUEST {
   logger(...args) {
     this.app._logger.level !== 'none' &&
       this.app._logLevels[args[0]] >=
-        this.app._logLevels[
-          this._sample ? this._sample : this.app._logger.level
-        ] &&
+      this.app._logLevels[
+      this._sample ? this._sample : this.app._logger.level
+      ] &&
       this._logs.push(this.app._logger.log(...args));
   }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -109,7 +109,7 @@ class RESPONSE {
     return this;
   }
 
-  // Returns boolean if header existss
+  // Returns boolean if header exists
   hasHeader(key) {
     return this.getHeader(key ? key : '') !== undefined;
   }

--- a/lib/response.js
+++ b/lib/response.js
@@ -88,15 +88,15 @@ class RESPONSE {
       return asArr
         ? this._headers
         : Object.keys(this._headers).reduce(
-          (headers, key) =>
-            Object.assign(headers, { [key]: this._headers[key].toString() }),
-          {}
-        ); // return all headers
+            (headers, key) =>
+              Object.assign(headers, { [key]: this._headers[key].toString() }),
+            {}
+          ); // return all headers
     return asArr
       ? this._headers[key.toLowerCase()]
       : this._headers[key.toLowerCase()]
-        ? this._headers[key.toLowerCase()].toString()
-        : undefined;
+      ? this._headers[key.toLowerCase()].toString()
+      : undefined;
   }
 
   getHeaders() {
@@ -127,9 +127,9 @@ class RESPONSE {
 
     this.header('Content-Type', 'application/json').send(
       (cb ? cb.replace(' ', '_') : 'callback') +
-      '(' +
-      this._serializer(body, ['application/json']).value +
-      ')'
+        '(' +
+        this._serializer(body, ['application/json']).value +
+        ')'
     );
   }
 
@@ -189,8 +189,8 @@ class RESPONSE {
       typeof expires === 'function'
         ? expires
         : typeof callback === 'function'
-          ? callback
-          : (e) => {
+        ? callback
+        : (e) => {
             if (e) this.error(e);
           };
 
@@ -232,10 +232,10 @@ class RESPONSE {
     cookieString +=
       opts.maxAge && !isNaN(opts.maxAge)
         ? '; MaxAge=' +
-        ((opts.maxAge / 1000) | 0) +
-        (!opts.expires
-          ? '; Expires=' + new Date(Date.now() + opts.maxAge).toUTCString()
-          : '')
+          ((opts.maxAge / 1000) | 0) +
+          (!opts.expires
+            ? '; Expires=' + new Date(Date.now() + opts.maxAge).toUTCString()
+            : '')
         : '';
 
     // path (String): Path for the cookie
@@ -249,9 +249,9 @@ class RESPONSE {
     cookieString +=
       opts.sameSite !== undefined
         ? '; SameSite=' +
-        (opts.sameSite === true
-          ? 'Strict'
-          : opts.sameSite === false
+          (opts.sameSite === true
+            ? 'Strict'
+            : opts.sameSite === false
             ? 'Lax'
             : opts.sameSite)
         : '';
@@ -319,7 +319,7 @@ class RESPONSE {
     let buffer, modified;
 
     let opts = typeof options === 'object' ? options : {};
-    let fn = typeof callback === 'function' ? callback : () => { };
+    let fn = typeof callback === 'function' ? callback : () => {};
 
     // Add optional parameter support
     if (typeof options === 'function') {
@@ -436,16 +436,16 @@ class RESPONSE {
       opts.methods
         ? opts.methods
         : acam
-          ? acam
-          : 'GET, PUT, POST, DELETE, OPTIONS'
+        ? acam
+        : 'GET, PUT, POST, DELETE, OPTIONS'
     );
     this.header(
       'Access-Control-Allow-Headers',
       opts.headers
         ? opts.headers
         : acah
-          ? acah
-          : 'Content-Type, Authorization, Content-Length, X-Requested-With'
+        ? acah
+        : 'Content-Type, Authorization, Content-Length, X-Requested-With'
     );
 
     // Optional CORS headers
@@ -496,8 +496,8 @@ class RESPONSE {
         date && typeof date.toUTCString === 'function'
           ? date
           : date && Date.parse(date)
-            ? new Date(date)
-            : new Date();
+          ? new Date(date)
+          : new Date();
       this.header('Last-Modified', lastModified.toUTCString());
     }
     return this;
@@ -505,9 +505,7 @@ class RESPONSE {
 
   setEncoding(contentEncoding) {
     if (this._response.multiValueHeaders) {
-      this._response.multiValueHeaders['content-encoding'] = [
-        contentEncoding,
-      ];
+      this._response.multiValueHeaders['content-encoding'] = [contentEncoding];
     } else {
       this._response.headers['content-encoding'] = contentEncoding;
     }
@@ -515,9 +513,7 @@ class RESPONSE {
 
   setContentType(contentType) {
     if (this._response.multiValueHeaders) {
-      this._response.multiValueHeaders['content-type'] = [
-        contentType,
-      ];
+      this._response.multiValueHeaders['content-type'] = [contentType];
     } else {
       this._response.headers['content-type'] = contentType;
     }
@@ -560,7 +556,11 @@ class RESPONSE {
       headers = { headers: UTILS.stringifyHeaders(this._headers) };
     }
 
-    const result = UTILS.encodeBody(this._request.method  === "HEAD" ? "" : body, this._serializer, parseAccept(this._request.headers, this._serializerPreferences))
+    const result = UTILS.encodeBody(
+      this._request.method === 'HEAD' ? '' : body,
+      this._serializer,
+      parseAccept(this._request.headers, this._serializerPreferences)
+    );
     // Create the response
     this._response = Object.assign(
       {},
@@ -573,16 +573,20 @@ class RESPONSE {
       },
       this._request.interface === 'alb'
         ? {
-          statusDescription: `${this._statusCode} ${UTILS.statusLookup(
-            this._statusCode
-          )}`,
-        }
+            statusDescription: `${this._statusCode} ${UTILS.statusLookup(
+              this._statusCode
+            )}`,
+          }
         : {}
     );
 
     if (this._response.body) {
       // Compress the body
-      if (this._compression && !result.isBase64Encoded && !result.contentEncoding) {
+      if (
+        this._compression &&
+        !result.isBase64Encoded &&
+        !result.contentEncoding
+      ) {
         const { data, contentEncoding } = compression.compress(
           this._response.body,
           this._request.headers,
@@ -603,10 +607,10 @@ class RESPONSE {
       }
 
       if (result && result.contentType) {
-        this.setContentType(result.contentType)
+        this.setContentType(result.contentType);
       }
       if (result && result.contentEncoding) {
-        this.setEncoding(result.contentEncoding)
+        this.setEncoding(result.contentEncoding);
       }
     }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -15,6 +15,7 @@ const { ResponseError, FileError } = require('./errors'); // Require custom erro
 
 // Require AWS S3 service
 const S3 = require('./s3-service');
+const { parseAccept } = require('./parsing.js');
 
 class RESPONSE {
   // Create the constructor function.
@@ -28,8 +29,9 @@ class RESPONSE {
     // Create a reference to the request
     this._request = request;
 
-    // Create a reference to the JSON serializer
+    // Create a reference to serializer
     this._serializer = app._serializer;
+    this._serializerPreferences = app._serializerPreferences;
 
     // Set the default state to processing
     this._state = 'processing';
@@ -86,15 +88,15 @@ class RESPONSE {
       return asArr
         ? this._headers
         : Object.keys(this._headers).reduce(
-            (headers, key) =>
-              Object.assign(headers, { [key]: this._headers[key].toString() }),
-            {}
-          ); // return all headers
+          (headers, key) =>
+            Object.assign(headers, { [key]: this._headers[key].toString() }),
+          {}
+        ); // return all headers
     return asArr
       ? this._headers[key.toLowerCase()]
       : this._headers[key.toLowerCase()]
-      ? this._headers[key.toLowerCase()].toString()
-      : undefined;
+        ? this._headers[key.toLowerCase()].toString()
+        : undefined;
   }
 
   getHeaders() {
@@ -107,16 +109,14 @@ class RESPONSE {
     return this;
   }
 
-  // Returns boolean if header exists
+  // Returns boolean if header existss
   hasHeader(key) {
     return this.getHeader(key ? key : '') !== undefined;
   }
 
   // Convenience method for JSON
   json(body) {
-    this.header('Content-Type', 'application/json').send(
-      this._serializer(body)
-    );
+    this.header('Content-Type', 'application/json').send(body);
   }
 
   // Convenience method for JSONP
@@ -127,9 +127,9 @@ class RESPONSE {
 
     this.header('Content-Type', 'application/json').send(
       (cb ? cb.replace(' ', '_') : 'callback') +
-        '(' +
-        this._serializer(body) +
-        ')'
+      '(' +
+      this._serializer(body, ['application/json']).value +
+      ')'
     );
   }
 
@@ -189,8 +189,8 @@ class RESPONSE {
       typeof expires === 'function'
         ? expires
         : typeof callback === 'function'
-        ? callback
-        : (e) => {
+          ? callback
+          : (e) => {
             if (e) this.error(e);
           };
 
@@ -214,7 +214,7 @@ class RESPONSE {
     let cookieString =
       (typeof name !== 'string' ? name.toString() : name) +
       '=' +
-      encodeURIComponent(UTILS.encodeBody(value));
+      encodeURIComponent(UTILS.encodeBody(value).value);
 
     // domain (String): Domain name for the cookie
     cookieString += opts.domain ? '; Domain=' + opts.domain : '';
@@ -232,10 +232,10 @@ class RESPONSE {
     cookieString +=
       opts.maxAge && !isNaN(opts.maxAge)
         ? '; MaxAge=' +
-          ((opts.maxAge / 1000) | 0) +
-          (!opts.expires
-            ? '; Expires=' + new Date(Date.now() + opts.maxAge).toUTCString()
-            : '')
+        ((opts.maxAge / 1000) | 0) +
+        (!opts.expires
+          ? '; Expires=' + new Date(Date.now() + opts.maxAge).toUTCString()
+          : '')
         : '';
 
     // path (String): Path for the cookie
@@ -249,9 +249,9 @@ class RESPONSE {
     cookieString +=
       opts.sameSite !== undefined
         ? '; SameSite=' +
-          (opts.sameSite === true
-            ? 'Strict'
-            : opts.sameSite === false
+        (opts.sameSite === true
+          ? 'Strict'
+          : opts.sameSite === false
             ? 'Lax'
             : opts.sameSite)
         : '';
@@ -319,7 +319,7 @@ class RESPONSE {
     let buffer, modified;
 
     let opts = typeof options === 'object' ? options : {};
-    let fn = typeof callback === 'function' ? callback : () => {};
+    let fn = typeof callback === 'function' ? callback : () => { };
 
     // Add optional parameter support
     if (typeof options === 'function') {
@@ -436,16 +436,16 @@ class RESPONSE {
       opts.methods
         ? opts.methods
         : acam
-        ? acam
-        : 'GET, PUT, POST, DELETE, OPTIONS'
+          ? acam
+          : 'GET, PUT, POST, DELETE, OPTIONS'
     );
     this.header(
       'Access-Control-Allow-Headers',
       opts.headers
         ? opts.headers
         : acah
-        ? acah
-        : 'Content-Type, Authorization, Content-Length, X-Requested-With'
+          ? acah
+          : 'Content-Type, Authorization, Content-Length, X-Requested-With'
     );
 
     // Optional CORS headers
@@ -496,11 +496,31 @@ class RESPONSE {
         date && typeof date.toUTCString === 'function'
           ? date
           : date && Date.parse(date)
-          ? new Date(date)
-          : new Date();
+            ? new Date(date)
+            : new Date();
       this.header('Last-Modified', lastModified.toUTCString());
     }
     return this;
+  }
+
+  setEncoding(contentEncoding) {
+    if (this._response.multiValueHeaders) {
+      this._response.multiValueHeaders['content-encoding'] = [
+        contentEncoding,
+      ];
+    } else {
+      this._response.headers['content-encoding'] = contentEncoding;
+    }
+  }
+
+  setContentType(contentType) {
+    if (this._response.multiValueHeaders) {
+      this._response.multiValueHeaders['content-type'] = [
+        contentType,
+      ];
+    } else {
+      this._response.headers['content-type'] = contentType;
+    }
   }
 
   // Sends the request to the main callback
@@ -540,6 +560,7 @@ class RESPONSE {
       headers = { headers: UTILS.stringifyHeaders(this._headers) };
     }
 
+    const result = UTILS.encodeBody(this._request.method  === "HEAD" ? "" : body, this._serializer, parseAccept(this._request.headers, this._serializerPreferences))
     // Create the response
     this._response = Object.assign(
       {},
@@ -547,40 +568,45 @@ class RESPONSE {
       cookies,
       {
         statusCode: this._statusCode,
-        body:
-          this._request.method === 'HEAD'
-            ? ''
-            : UTILS.encodeBody(body, this._serializer),
+        body: result.value,
         isBase64Encoded: this._isBase64,
       },
       this._request.interface === 'alb'
         ? {
-            statusDescription: `${this._statusCode} ${UTILS.statusLookup(
-              this._statusCode
-            )}`,
-          }
+          statusDescription: `${this._statusCode} ${UTILS.statusLookup(
+            this._statusCode
+          )}`,
+        }
         : {}
     );
 
-    // Compress the body
-    if (this._compression && this._response.body) {
-      const { data, contentEncoding } = compression.compress(
-        this._response.body,
-        this._request.headers,
-        Array.isArray(this._compression) ? this._compression : null
-      );
-      if (contentEncoding) {
+    if (this._response.body) {
+      // Compress the body
+      if (this._compression && !result.isBase64Encoded && !result.contentEncoding) {
+        const { data, contentEncoding } = compression.compress(
+          this._response.body,
+          this._request.headers,
+          Array.isArray(this._compression) ? this._compression : null
+        );
+        if (contentEncoding) {
+          Object.assign(this._response, {
+            body: data.toString('base64'),
+            isBase64Encoded: true,
+          });
+          this.setEncoding(contentEncoding);
+        }
+      } else if (Buffer.isBuffer(this._response.body)) {
         Object.assign(this._response, {
-          body: data.toString('base64'),
+          body: this._response.body.toString('base64'),
           isBase64Encoded: true,
         });
-        if (this._response.multiValueHeaders) {
-          this._response.multiValueHeaders['content-encoding'] = [
-            contentEncoding,
-          ];
-        } else {
-          this._response.headers['content-encoding'] = contentEncoding;
-        }
+      }
+
+      if (result && result.contentType) {
+        this.setContentType(result.contentType)
+      }
+      if (result && result.contentEncoding) {
+        this.setEncoding(result.contentEncoding)
       }
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,26 +32,33 @@ exports.encodeUrl = (url) =>
     .replace(UNMATCHED_SURROGATE_PAIR_REGEXP, UNMATCHED_SURROGATE_PAIR_REPLACE)
     .replace(ENCODE_CHARS_REGEXP, encodeURI);
 
-const encodeBody = (body, serializer) => {
-  const encode = typeof serializer === 'function' ? serializer : JSON.stringify;
-  return typeof body === 'object'
-    ? encode(body)
-    : body && typeof body !== 'string'
-    ? body.toString()
-    : body
-    ? body
-    : '';
-};
+const encodeBody = (body, serializer, acceptableMedia) => {
+  if (!body) {
+    return {
+      value: ""
+    }
+  }
+
+  if (typeof body === 'object') {
+    if (typeof serializer === 'function') {
+      return serializer(body, acceptableMedia);
+    }
+    return this.stringifyBody(body, undefined)
+  }
+  return {
+    value: typeof body !== 'string' ? body.toString() : body
+  }
+}
 
 exports.encodeBody = encodeBody;
 
 exports.parsePath = (path) => {
   return path
     ? path
-        .trim()
-        .split('?')[0]
-        .replace(/^\/(.*?)(\/)*$/, '$1')
-        .split('/')
+      .trim()
+      .split('?')[0]
+      .replace(/^\/(.*?)(\/)*$/, '$1')
+      .split('/')
     : [];
 };
 
@@ -60,6 +67,14 @@ exports.parseBody = (body) => {
     return JSON.parse(body);
   } catch (e) {
     return body;
+  }
+};
+
+exports.stringifyBody = (body, _) => {
+  return {
+    value: JSON.stringify(body),
+    contentType: "application/json",
+    isBase64Encoded: false
   }
 };
 
@@ -111,6 +126,7 @@ exports.mimeLookup = (input, custom = {}) => {
 };
 
 const statusCodes = require('./statusCodes.js'); // MIME Map
+const { parseAccept } = require('./parsing');
 
 exports.statusLookup = (status) => {
   return status in statusCodes ? statusCodes[status] : 'Unknown';
@@ -141,9 +157,9 @@ exports.extractRoutes = extractRoutes;
 exports.generateEtag = (data) =>
   crypto
     .createHash('sha256')
-    .update(encodeBody(data))
+    .update(encodeBody(data).value)
     .digest('hex')
-    .substr(0, 32);
+    .substring(0, 32);
 
 // Check if valid S3 path
 exports.isS3 = (path) => /^s3:\/\/.+\/.+/i.test(path);
@@ -202,3 +218,5 @@ exports.stringifyHeaders = (headers) =>
       }),
     {}
   );
+
+

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,30 +35,30 @@ exports.encodeUrl = (url) =>
 const encodeBody = (body, serializer, acceptableMedia) => {
   if (!body) {
     return {
-      value: ""
-    }
+      value: '',
+    };
   }
 
   if (typeof body === 'object') {
     if (typeof serializer === 'function') {
       return serializer(body, acceptableMedia);
     }
-    return this.stringifyBody(body, undefined)
+    return this.stringifyBody(body, undefined);
   }
   return {
-    value: typeof body !== 'string' ? body.toString() : body
-  }
-}
+    value: typeof body !== 'string' ? body.toString() : body,
+  };
+};
 
 exports.encodeBody = encodeBody;
 
 exports.parsePath = (path) => {
   return path
     ? path
-      .trim()
-      .split('?')[0]
-      .replace(/^\/(.*?)(\/)*$/, '$1')
-      .split('/')
+        .trim()
+        .split('?')[0]
+        .replace(/^\/(.*?)(\/)*$/, '$1')
+        .split('/')
     : [];
 };
 
@@ -73,9 +73,9 @@ exports.parseBody = (body) => {
 exports.stringifyBody = (body, _) => {
   return {
     value: JSON.stringify(body),
-    contentType: "application/json",
-    isBase64Encoded: false
-  }
+    contentType: 'application/json',
+    isBase64Encoded: false,
+  };
 };
 
 // Parses auth values into known formats
@@ -218,5 +218,3 @@ exports.stringifyHeaders = (headers) =>
       }),
     {}
   );
-
-


### PR DESCRIPTION
While there are a lot of changes to the best of my knowledge none of them are breaking. All the unit test work.


- Remove toString() on Buffer.from which was converting raw buffers to unicode strings
- Added out-of-band deserializer
- Fix code so that it respects the content-type header and doesn't default to parsing everything as JSON
- Convert body from buffer to string where necessary
- Change serializer behavior
- Make encodeBody logic clearer
- Convert buffers to base64 automatically
- Added a parser for the Accept header
- Added a new SerializerOption interface
- Acceptable content types are forwarded into the serializer delegate
- The serializer can control the response content-type and content-encoding
- Fixed behavior raised by unit test
- Raise an error in request building when JSON.parse fails.

