### PR TITLE
Misc Fixes 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export declare interface CookieOptions {
   maxAge?: number;
   path?: string;
   secure?: boolean;
-  sameSite?: boolean | 'Strict' | 'Lax';
+  sameSite?: boolean | 'Strict' | 'Lax' | 'None';
 }
 
 export declare interface CorsOptions {
@@ -59,7 +59,7 @@ export declare type HandlerFunction = (
   res: Response,
   next?: NextFunction
 ) => void | any | Promise<any>;
-export declare type LoggerFunction = (message: string) => void;
+export declare type LoggerFunction = (message?: any, ...optionalParams: any[]) => void;
 export declare type NextFunction = () => void;
 export declare type TimestampFunction = () => string;
 export declare type DeserializerFunction = (
@@ -218,7 +218,7 @@ export declare class Response {
   json(body: any): void;
   jsonp(body: any): void;
   html(body: any): void;
-  type(type: string): void;
+  type(type: string): this;
   location(path: string): this;
   redirect(status: number, path: string): void;
   redirect(path: string): void;
@@ -276,8 +276,7 @@ export declare class API {
 
   use(path: string, ...middleware: Middleware[]): void;
   use(paths: string[], ...middleware: Middleware[]): void;
-  use(...middleware: Middleware[]): void;
-  use(...errorHandlingMiddleware: ErrorHandlingMiddleware[]): void;
+  use(...middleware: (Middleware | ErrorHandlingMiddleware)[]): void;
 
   finally(callback: FinallyFunction): void;
 

--- a/index.js
+++ b/index.js
@@ -412,11 +412,12 @@ class API {
       for (const err of this._errors) {
         if (response._state === 'done') break;
         // Promisify error middleware
-        await new Promise((r) => {
-          let rtn = err(e, response._request, response, () => {
+        await new Promise(async (r) => {
+          let rtn = await err(e, response._request, response, () => {
             r();
           });
           if (rtn) response.send(rtn);
+          r();
         });
       } // end for
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -58,7 +58,7 @@ exports.parsePath = (path) => {
         .trim()
         .split('?')[0]
         .replace(/^\/(.*?)(\/)*$/, '$1')
-        .split('/')
+        .split('/').map(str => decodeURIComponent(str))
     : [];
 };
 


### PR DESCRIPTION
fix: error handling middleware issue

Actually await error handling middleware

fix: logger function should accept second arguments

fix: align typescript type with code expectation for use function.

 Allow for array of middleware inputs to either be standard middleware or normal middleware.

fix: typing for Response#type function

It is valid to chain `response.type('application/xml').status(200).send(xml)` because the `type` function returns an instance of **this**. This change correct the `index.d.ts` typing description from incorrectly returning **void** to correctly returning **this** as apparent from `lib/response.js` .

fix: add 'None' to as possible sameSite value